### PR TITLE
Use systemctl to restart key server

### DIFF
--- a/bash/sync_keydb.sh
+++ b/bash/sync_keydb.sh
@@ -13,4 +13,4 @@ then
   exit 0
 fi
 mv -f keys.db.new keys.db
-sudo restart keyserver
+sudo systemctl restart keyserver


### PR DESCRIPTION
Keyserver did not restart due to missing 'systemctl' on script line.